### PR TITLE
Small changes to help Gimmel work on embedded

### DIFF
--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -174,6 +174,10 @@ namespace giml {
             this->enabled = false;
         }
 
+        virtual void toggleEffect() {
+            this->enabled = !(this->enabled);
+        }
+
         virtual inline T processSample(const T& in) {
             return in;
         }

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -174,7 +174,7 @@ namespace giml {
             this->enabled = false;
         }
         
-        virtual void toggleEffect() {
+        virtual void toggle() {
             this->enabled = !(this->enabled);
         }
 

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -173,7 +173,7 @@ namespace giml {
         virtual void disable() {
             this->enabled = false;
         }
-
+        
         virtual void toggleEffect() {
             this->enabled = !(this->enabled);
         }
@@ -299,7 +299,7 @@ namespace giml {
             if (delayInSamples >= this->bufferSize) { // limit delay to maxIndex
                 delayInSamples = this->bufferSize - 1;
             }
-            long long int readIndex = this->writeIndex - delayInSamples; // calculate readIndex
+            long int readIndex = this->writeIndex - delayInSamples; // calculate readIndex
             if (readIndex < 0) {
                 readIndex += this->bufferSize; // circular logic
             }
@@ -440,14 +440,14 @@ namespace giml {
         T& operator[](size_t index) {
             if (index >= this->length || index < 0) {
                 printf("Array access out of bounds/n");
-                throw std::out_of_range("Index out of range");
+                //throw std::out_of_range("Index out of range");
             }
             return this->pBackingArr[index];
         }
         const T& operator[](size_t index) const {
             if (index >= this->length || index < 0) {
                 printf("Array access out of bounds/n");
-                throw std::out_of_range("Index out of range");
+                //throw std::out_of_range("Index out of range");
             }
             return this->pBackingArr[index];
         }


### PR DESCRIPTION
Non-invasive changes to Gimmel:
- `toggleEffect()` to help with switches
- `long long int` -> `long int` to bring it down to 32-bit from 64-bit declaration